### PR TITLE
Fix absolute path in config

### DIFF
--- a/cron/config.php
+++ b/cron/config.php
@@ -14,7 +14,7 @@
 */
 
 
-$config = parse_ini_file(realpath("../.env"));
+$config = parse_ini_file(realpath(__DIR__. "/../.env"));
 
 $db_connection = "mysql:host=" . $config['DB_HOST'] . ";dbname=" . $config['DB_DATABASE'] . ";charset=utf8";
 


### PR DESCRIPTION
Previously, the path was causing issues and prevented a good executions of cron jobs. Example: `php <Absolute_path>/cron/male_improve_bot.php` would throw a fatal error `Fatal error:  Uncaught ValueError: parse_ini_file()`. The issue is now fixed.